### PR TITLE
Use namespaced template paths for Symfony

### DIFF
--- a/src/Gyro/Bundle/MVCBundle/View/SymfonyConventionsTemplateGuesser.php
+++ b/src/Gyro/Bundle/MVCBundle/View/SymfonyConventionsTemplateGuesser.php
@@ -57,11 +57,13 @@ class SymfonyConventionsTemplateGuesser implements TemplateGuesser
 
     private function createTemplateReference(string $bundleName, string $controllerName, ?string $actionName, string $format, string $engine): string
     {
+        $templatePath = sprintf('%s/%s.%s.%s', $controllerName, (string) $actionName, $format, $engine);
+
         if (!$bundleName) {
-            return sprintf('%s/%s.%s.%s', $controllerName, (string) $actionName, $format, $engine);
+            return $templatePath;
         }
 
-        return sprintf('%s:%s:%s.%s.%s', $bundleName, $controllerName, (string) $actionName, $format, $engine);
+        return sprintf('@%s/%s', str_replace('Bundle', '', $bundleName), $templatePath);
     }
 
     /** @return array<int,string> */

--- a/tests/View/SymfonyConventionsTemplateGuesserTest.php
+++ b/tests/View/SymfonyConventionsTemplateGuesserTest.php
@@ -25,10 +25,10 @@ class SymfonyConventionsTemplateGuesserTest extends TestCase
      */
     public function it_converts_convention_controller_to_template_reference() : void
     {
-        \Phake::when($this->bundleLocation)->locationFor('Controller\\FooController')->thenReturn('Bundle');
+        \Phake::when($this->bundleLocation)->locationFor('Controller\\FooController')->thenReturn('CoreBundle');
 
         $this->assertEquals(
-            'Bundle:Foo:bar.html.twig',
+            '@Core/Foo/bar.html.twig',
             $this->guesser->guessControllerTemplateName('Controller\\FooController::barAction', null, 'html', 'twig')
         );
     }
@@ -38,10 +38,10 @@ class SymfonyConventionsTemplateGuesserTest extends TestCase
      */
     public function it_converts_any_suffixed_controller_to_template_reference() : void
     {
-        \Phake::when($this->bundleLocation)->locationFor('Product\\ProductController')->thenReturn('Bundle');
+        \Phake::when($this->bundleLocation)->locationFor('Product\\ProductController')->thenReturn('CoreBundle');
 
         $this->assertEquals(
-            'Bundle:Product:list.html.twig',
+            '@Core/Product/list.html.twig',
             $this->guesser->guessControllerTemplateName('Product\\ProductController::listAction', null, 'html', 'twig')
         );
     }
@@ -52,10 +52,10 @@ class SymfonyConventionsTemplateGuesserTest extends TestCase
     public function it_uses_parser_when_converting_non_callable_controller_to_template_reference() : void
     {
         \Phake::when($this->parser)->parse('foo:barAction')->thenReturn('Controller\\FooController::barAction');
-        \Phake::when($this->bundleLocation)->locationFor('Controller\\FooController')->thenReturn('Bundle');
+        \Phake::when($this->bundleLocation)->locationFor('Controller\\FooController')->thenReturn('CoreBundle');
 
         $this->assertEquals(
-            'Bundle:Foo:bar.html.twig',
+            '@Core/Foo/bar.html.twig',
             $this->guesser->guessControllerTemplateName('Controller\\FooController::barAction', null, 'html', 'twig')
         );
     }
@@ -66,10 +66,10 @@ class SymfonyConventionsTemplateGuesserTest extends TestCase
     public function it_uses_provided_action_name_as_overwrite() : void
     {
         \Phake::when($this->parser)->parse('foo:barAction')->thenReturn('Controller\\FooController::barAction');
-        \Phake::when($this->bundleLocation)->locationFor('Controller\\FooController')->thenReturn('Bundle');
+        \Phake::when($this->bundleLocation)->locationFor('Controller\\FooController')->thenReturn('CoreBundle');
 
         $this->assertEquals(
-            'Bundle:Foo:baz.html.twig',
+            '@Core/Foo/baz.html.twig',
             $this->guesser->guessControllerTemplateName('Controller\\FooController::barAction', 'baz', 'html', 'twig')
         );
     }
@@ -80,7 +80,7 @@ class SymfonyConventionsTemplateGuesserTest extends TestCase
     public function it_detects_symfony_flex_controllers() : void
     {
         \Phake::when($this->parser)->parse('foo:barAction')->thenReturn('App\\Controller\\FooController::barAction');
-        \Phake::when($this->bundleLocation)->locationFor('App\\Controller\\FooController')->thenReturn('Bundle');
+        \Phake::when($this->bundleLocation)->locationFor('App\\Controller\\FooController')->thenReturn('CoreBundle');
 
         $this->assertEquals(
             'Foo/baz.html.twig',


### PR DESCRIPTION
This changes the template reference resolution for Symfony controller actions to use the newer namespaced template paths vs. the older colon-separated syntax.

Old version: `FooBundle:Folder:Subfolder:template.html.twig`
Namespaced Version: `@Foo/Folder/Subfolder/template.html.twig`

Starting with Symfony 5 the old syntax does not seem to work in all cases anymore. In Symfony 4 there seem to be resolution issues with this when not using the now deprecated framework templating integration (`framework.templating` config) to enable Twig. Unfortunately, I couldn't quite pinpoint what change exactly drops the support for the old syntax but the newer syntax has been suggested in the official [Symfony docs](https://symfony.com/doc/4.4/templates.html#template-namespaces) for a couple of major versions now, so I feel like this change is generally beneficial.

These namespaced paths are available since before Symfony 4 so there should not be any compatibility issues with the currently supported versions.