### PR TITLE
[GH-21] Address ReflectionParameter::getClass deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['8.0', '8.1']
         composer: ['--prefer-lowest', ' ']
 
     steps:
@@ -43,7 +43,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 7.4
+        php-version: 8.0
         tools: "cs2pr"
 
     - name: "Cache dependencies installed with composer"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         {"name": "Benjamin Eberlei", "email": "kontakt@beberlei.de"}
     ],
     "require-dev": {
-        "php": "~7.4|~8.0",
+        "php": "~8.0",
         "phake/phake": "^4.2.0",
         "phpunit/phpunit": "^9.4",
         "vimeo/psalm": "4.15.0",

--- a/src/Gyro/Bundle/MVCBundle/EventListener/ParamConverterListener.php
+++ b/src/Gyro/Bundle/MVCBundle/EventListener/ParamConverterListener.php
@@ -51,11 +51,18 @@ class ParamConverterListener
 
         // automatically apply conversion for non-configured objects
         foreach ($r->getParameters() as $param) {
-            if (!$param->getClass() || $param->getClass()->isInstance($request)) {
+            if (!$param->getType()) {
                 continue;
             }
 
-            $class = $param->getClass()->getName();
+            $type = $param->getType();
+
+            // skip union and intersection types (for now?)
+            if (!($type instanceof \ReflectionNamedType)) {
+                continue;
+            }
+
+            $class = $type->getName();
             $name = $param->getName();
 
             if (

--- a/tests/EventListener/ParamConverterListenerTest.php
+++ b/tests/EventListener/ParamConverterListenerTest.php
@@ -47,6 +47,23 @@ class ParamConverterListenerTest extends TestCase
     /**
      * @test
      */
+    public function it_skips_union_types() : void
+    {
+        $request = new Request();
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $method = function (Session|TokenContext $context) : void {
+        };
+        $event = $this->createControllerEvent($method, $request);
+
+        $this->listener->onKernelController($event);
+
+        $this->assertFalse($request->attributes->has('context'));
+    }
+
+    /**
+     * @test
+     */
     public function it_supports_array_contollers() : void
     {
         $controller = new class()


### PR DESCRIPTION
Use the new `ReflectionParameter::getType()` API instead to get rid of the deprecation.

Bump lowest PHP version to 8.0 to allow test with union types without workarounds.