### PR TITLE
Inject services directly instead of using container.

### DIFF
--- a/src/Gyro/Bundle/MVCBundle/ParamConverter/SymfonyServiceProvider.php
+++ b/src/Gyro/Bundle/MVCBundle/ParamConverter/SymfonyServiceProvider.php
@@ -2,36 +2,32 @@
 
 namespace Gyro\Bundle\MVCBundle\ParamConverter;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class SymfonyServiceProvider implements ServiceProvider
 {
-    /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface
-     */
-    private $container;
-
-    public function __construct(ContainerInterface $container)
-    {
-        $this->container = $container;
+    public function __construct(
+        private ?FormFactoryInterface $formFactory,
+        private ?TokenStorageInterface $tokenStorage,
+        private ?AuthorizationCheckerInterface $authorizationChecker,
+    ) {
     }
 
     public function getFormFactory(): FormFactoryInterface
     {
-        return $this->throwOnNull($this->container->get('form.factory'));
+        return $this->throwOnNull($this->formFactory);
     }
 
     public function getTokenStorage(): TokenStorageInterface
     {
-        return $this->throwOnNull($this->container->get('security.token_storage'));
+        return $this->throwOnNull($this->tokenStorage);
     }
 
     public function getAuthorizationChecker(): AuthorizationCheckerInterface
     {
-        return $this->throwOnNull($this->container->get('security.authorization_checker'));
+        return $this->throwOnNull($this->authorizationChecker);
     }
 
     private function throwOnNull(?object $service): object

--- a/src/Gyro/Bundle/MVCBundle/Resources/config/services.xml
+++ b/src/Gyro/Bundle/MVCBundle/Resources/config/services.xml
@@ -66,7 +66,9 @@
         </service>
 
         <service id="gyro_mvc.param_converter.service_provider" class="Gyro\Bundle\MVCBundle\ParamConverter\SymfonyServiceProvider">
-            <argument type="service" id="service_container" />
+            <argument type="service" id="form.factory" on-invalid="null" />
+            <argument type="service" id="security.token_storage" on-invalid="null" />
+            <argument type="service" id="security.authorization_checker" on-invalid="null" />
         </service>
 
         <service id="gyro_mvc.param_converter_listener" class="Gyro\Bundle\MVCBundle\EventListener\ParamConverterListener">

--- a/tests/EventListener/ParamConverterListenerTest.php
+++ b/tests/EventListener/ParamConverterListenerTest.php
@@ -118,16 +118,11 @@ class ParamConverterListenerTest extends TestCase
      */
     public function setUp() : void
     {
-        $container = new Container();
-        $container->set(
-            'security.token_storage',
-            \Phake::mock(TokenStorageInterface::class)
+        $serviceProvider = new SymfonyServiceProvider(
+            null,
+            \Phake::mock(TokenStorageInterface::class),
+            \Phake::mock(AuthorizationCheckerInterface::class),
         );
-        $container->set(
-            'security.authorization_checker',
-            \Phake::mock(AuthorizationCheckerInterface::class)
-        );
-        $serviceProvider = new SymfonyServiceProvider($container);
 
         $this->kernel   = \Phake::mock(HttpKernelInterface::class);
         $this->listener = new ParamConverterListener($serviceProvider);


### PR DESCRIPTION
Fixes

> ServiceNotFoundException
>
> The "form.factory" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.