### PR TITLE
PHP-7.4-Compatibility: Don't use constructor property promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1']
         composer: ['--prefer-lowest', ' ']
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         {"name": "Benjamin Eberlei", "email": "kontakt@beberlei.de"}
     ],
     "require-dev": {
-        "php": "~8.0",
+        "php": "~7.4|~8.0",
         "phake/phake": "^4.2.0",
         "phpunit/phpunit": "^9.4",
         "vimeo/psalm": "4.15.0",

--- a/src/Gyro/Bundle/MVCBundle/ParamConverter/SymfonyServiceProvider.php
+++ b/src/Gyro/Bundle/MVCBundle/ParamConverter/SymfonyServiceProvider.php
@@ -8,11 +8,18 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class SymfonyServiceProvider implements ServiceProvider
 {
+    private ?FormFactoryInterface $formFactory;
+    private ?TokenStorageInterface $tokenStorage;
+    private ?AuthorizationCheckerInterface $authorizationChecker;
+
     public function __construct(
-        private ?FormFactoryInterface $formFactory,
-        private ?TokenStorageInterface $tokenStorage,
-        private ?AuthorizationCheckerInterface $authorizationChecker,
+        ?FormFactoryInterface $formFactory,
+        ?TokenStorageInterface $tokenStorage,
+        ?AuthorizationCheckerInterface $authorizationChecker
     ) {
+        $this->formFactory = $formFactory;
+        $this->tokenStorage = $tokenStorage;
+        $this->authorizationChecker = $authorizationChecker;
     }
 
     public function getFormFactory(): FormFactoryInterface


### PR DESCRIPTION
Right now, we are using the qafoolabs/no-framework-bundle with symfony 4 and are working towards a symfony 5 upgrade.
Since qafoolabs/no-framework-bundle is not compatible with Symfony 5, we tried to switch to using this bundle but realized that this bundle requires php 8 with the latest tag.
Right now, we are still running on php 7.4 with symfony 4 and it would be great if we could support both worlds, symfony 4 on php 7.4 and symfony 5 on php 8, in order to provide a smooth upgrade path.

While this bundle does not require a specific php version (except for development), I only found this class uses php 8 features and therefore breaks php 7.4 compatibility.

It would be great if we could make this php 7.4 compatible again.