### PR TITLE
yield AfterResponseTask will delay code execution to kernel.terminate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 composer.lock
 .phpunit.result.cache
 .phpcs-cache
+.idea

--- a/README.md
+++ b/README.md
@@ -221,6 +221,24 @@ class DefaultController
 }
 ```
 
+## Execute code after the response was sent
+
+For a simple way to delay work from the controller to Symfony's `kernel.terminate` event 
+the Gyro's yield applier abstraction handles a `AfterResponseTask` that accepts a closure
+to be executed after `Response::send` is called via event subscriber.
+
+```php
+public function registerAction($request): RedirectRoute
+{
+    $user = $this->createUser($request);
+    $this->entityManager->persist($user);
+
+    yield new AfterResponseTask(fn () => $this->sendEmail($user));
+
+    return new RedirectRoute('home');
+}
+```
+
 ## Inject TokenContext into actions
 
 In Symfony access to security related information is available through the

--- a/src/Gyro/Bundle/MVCBundle/Controller/ResultConverter/AfterResponseYieldApplier.php
+++ b/src/Gyro/Bundle/MVCBundle/Controller/ResultConverter/AfterResponseYieldApplier.php
@@ -10,15 +10,24 @@ use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
 class AfterResponseYieldApplier implements ControllerYieldApplier, EventSubscriberInterface
 {
-    private $tasks = [];
+    /** @var array<callable> */
+    private array $tasks = [];
 
+    /**
+     * @param mixed $yield
+     */
     public function supports($yield): bool
     {
         return $yield instanceof AfterResponseTask;
     }
 
+    /**
+     * @param mixed $yield
+     */
     public function apply($yield, Request $request, Response $response): void
     {
+        assert(is_callable($yield));
+
         $this->tasks[] = $yield;
     }
 
@@ -29,6 +38,9 @@ class AfterResponseYieldApplier implements ControllerYieldApplier, EventSubscrib
         }
     }
 
+    /**
+     * @psalm-return array<string, string|array{0: string, 1: int}|list<array{0: string, 1?: int}>>
+     */
     public static function getSubscribedEvents()
     {
         return ['kernel.terminate' => 'onKernelTerminate'];

--- a/src/Gyro/Bundle/MVCBundle/Controller/ResultConverter/AfterResponseYieldApplier.php
+++ b/src/Gyro/Bundle/MVCBundle/Controller/ResultConverter/AfterResponseYieldApplier.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Gyro\Bundle\MVCBundle\Controller\ResultConverter;
+
+use Gyro\MVC\AfterResponseTask;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
+
+class AfterResponseYieldApplier implements ControllerYieldApplier, EventSubscriberInterface
+{
+    private $tasks = [];
+
+    public function supports($yield): bool
+    {
+        return $yield instanceof AfterResponseTask;
+    }
+
+    public function apply($yield, Request $request, Response $response): void
+    {
+        $this->tasks[] = $yield;
+    }
+
+    public function onKernelTerminate(TerminateEvent $event): void
+    {
+        foreach ($this->tasks as $task) {
+            $task();
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return ['kernel.terminate' => 'onKernelTerminate'];
+    }
+}

--- a/src/Gyro/Bundle/MVCBundle/Controller/ResultConverter/ArrayToTemplateResponseConverter.php
+++ b/src/Gyro/Bundle/MVCBundle/Controller/ResultConverter/ArrayToTemplateResponseConverter.php
@@ -21,7 +21,7 @@ class ArrayToTemplateResponseConverter implements ControllerResultConverter
     private $guesser;
     private $engine;
 
-    public function __construct(Environment $twig, TemplateGuesser $guesser, string $engine)
+    public function __construct(?Environment $twig, TemplateGuesser $guesser, string $engine)
     {
         $this->twig = $twig;
         $this->guesser = $guesser;

--- a/src/Gyro/Bundle/MVCBundle/Controller/ResultConverter/ArrayToTemplateResponseConverter.php
+++ b/src/Gyro/Bundle/MVCBundle/Controller/ResultConverter/ArrayToTemplateResponseConverter.php
@@ -58,6 +58,10 @@ class ArrayToTemplateResponseConverter implements ControllerResultConverter
 
     private function makeResponseFor(string $controller, TemplateView $templateView, string $requestFormat): Response
     {
+        if ($this->twig === null) {
+            throw new \RuntimeException('Cannot convert to template response without Twig');
+        }
+
         $viewName = $this->guesser->guessControllerTemplateName(
             $controller,
             $templateView->getActionTemplateName(),

--- a/src/Gyro/Bundle/MVCBundle/Resources/config/services.xml
+++ b/src/Gyro/Bundle/MVCBundle/Resources/config/services.xml
@@ -15,7 +15,7 @@
             <call method="addConverter">
                 <argument type="service">
                     <service class="Gyro\Bundle\MVCBundle\Controller\ResultConverter\ArrayToTemplateResponseConverter">
-                        <argument type="service" id="twig" />
+                        <argument type="service" id="twig" on-invalid="null" />
                         <argument type="service" id="gyro_mvc.template_guesser" />
                         <argument>twig</argument>
                     </service>

--- a/src/Gyro/Bundle/MVCBundle/Resources/config/services.xml
+++ b/src/Gyro/Bundle/MVCBundle/Resources/config/services.xml
@@ -47,6 +47,14 @@
                     <service class="Gyro\Bundle\MVCBundle\Controller\ResultConverter\FlashYieldApplier" />
                 </argument>
             </call>
+
+            <call method="addYieldApplier">
+                <argument type="service" id="Gyro\Bundle\MVCBundle\Controller\ResultConverter\AfterResponseYieldApplier" />
+            </call>
+        </service>
+
+        <service id="Gyro\Bundle\MVCBundle\Controller\ResultConverter\AfterResponseYieldApplier">
+            <tag name="kernel.event_subscriber" />
         </service>
 
         <service id="gyro_mvc.template_guesser" class="Gyro\Bundle\MVCBundle\View\SymfonyConventionsTemplateGuesser">

--- a/src/Gyro/MVC/AfterResponseTask.php
+++ b/src/Gyro/MVC/AfterResponseTask.php
@@ -11,7 +11,7 @@ class AfterResponseTask
         $this->callable = $callable;
     }
 
-    public function __invoke()
+    public function __invoke(): void
     {
         $callable = $this->callable;
         $callable();

--- a/src/Gyro/MVC/AfterResponseTask.php
+++ b/src/Gyro/MVC/AfterResponseTask.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Gyro\MVC;
+
+class AfterResponseTask
+{
+    private $callable;
+
+    public function __construct(callable $callable)
+    {
+        $this->callable = $callable;
+    }
+
+    public function __invoke()
+    {
+        $callable = $this->callable;
+        $callable();
+    }
+}

--- a/tests/Controller/ResultConverter/AfterResponseTaskYieldApplierTest.php
+++ b/tests/Controller/ResultConverter/AfterResponseTaskYieldApplierTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Controller\ResultConverter;
+
+use Gyro\Bundle\MVCBundle\Controller\ResultConverter\AfterResponseYieldApplier;
+use Gyro\MVC\AfterResponseTask;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class AfterResponseTaskYieldApplierTest extends TestCase
+{
+    private $taskExecuted = false;
+
+    public function testEndToEnd(): void
+    {
+        $request = new Request();
+        $response = new Response();
+        $kernel = \Phake::mock(HttpKernelInterface::class);
+
+        $yieldApplier = new AfterResponseYieldApplier();
+        $task = new AfterResponseTask(fn () => $this->taskExecuted = true);
+
+        $this->assertTrue($yieldApplier->supports($task));
+
+        $yieldApplier->apply($task, $request, $response);
+
+        $this->assertFalse($this->taskExecuted);
+
+        $yieldApplier->onKernelTerminate(new TerminateEvent($kernel, $request, $response));
+
+        $this->assertTrue($this->taskExecuted);
+    }
+}


### PR DESCRIPTION
For a simple way to delay work from the controller to `kernel.terminate` this extends Gyro's yield applier abstraction to handle a new `AfterResponseTask` that accepts a closure to be executed after `Response::send` is called via a kernel.terminate event subscriber.

```php
public function registerAction($request): RedirectRoute
{
     $user = $this->createUser($request);
     $this->entityManager->persist($user);

     yield new AfterResponseTask(fn () => $this->sendEmail($user));

     return new RedirectRoute('home');
}
```
