### PR TITLE
Fix test for skipping union types

### DIFF
--- a/tests/EventListener/ParamConverterListenerTest.php
+++ b/tests/EventListener/ParamConverterListenerTest.php
@@ -20,6 +20,8 @@ function iAmAController(TokenContext $context) : void
 {
 }
 
+#[PHP8] function iAmAFunctionWithAUnionTypeParameter(Session|TokenContext $context): void {}
+
 class ParamConverterListenerTest extends TestCase
 {
     private $kernel;
@@ -49,12 +51,14 @@ class ParamConverterListenerTest extends TestCase
      */
     public function it_skips_union_types() : void
     {
+        if (version_compare(phpversion(), '8.0') < 0) {
+            self::markTestSkipped('Union types are only available for PHP>=8.0');
+        }
+
         $request = new Request();
         $request->setSession(new Session(new MockArraySessionStorage()));
 
-        $method = function ($context) : void {
-        };
-        $event = $this->createControllerEvent($method, $request);
+        $event = $this->createControllerEvent('Gyro\Bundle\MVCBundle\Tests\EventListener\iAmAFunctionWithAUnionTypeParameter', $request);
 
         $this->listener->onKernelController($event);
 


### PR DESCRIPTION
Maybe it's a bit hacky but the fix in https://github.com/gyro-project/mvc-bundle/commit/88a048eeb19e20ac4b7d71ee598a536338d1c004 made the test for skipping union types obsolete and with this hacky solution, the test is skipped with php 7.4 but executed with the correct behaviour (I think) with php >= 8.0.
I'm not sure if it is the best solution for this problem but at least I wanted to propose it. :smile: 